### PR TITLE
Make devel vms install katello-devel-installer

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -202,7 +202,7 @@ system('yum -y update puppet')
 if options.has_key?(:devel)
   system('yum -y install rubygems')
   system('yum -y install rubygem-kafo')
-  system('yum -y install katello-installer')
+  system('yum -y install katello-devel-installer')
 else
   system('yum -y install katello')
 end


### PR DESCRIPTION
Currently ```vagrant up centos7-devel``` installs katello-installer and fails when trying to provision by running katello-devel-installer