### PR TITLE
Download scratch builds and create local repo from Koji task ID.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ boxes.yaml
 plugins
 .idea
 scripts
+repo

--- a/lib/koji-downloader.rb
+++ b/lib/koji-downloader.rb
@@ -1,0 +1,46 @@
+require 'open-uri'
+
+
+class KojiDownloader
+
+  attr_reader :task_id, :directory
+
+  KOJI_URL = "http://koji.katello.org"
+
+  def initialize(args)
+    @task_id = args.fetch(:task_id)
+    @directory = args.fetch(:directory)
+  end
+
+  def download
+    puts "Starting Koji package download"
+
+    if !File.exist?(@directory)
+      Dir.mkdir(@directory)
+    end
+
+    packages_in_build.each do |package|
+      download_scratch_build(package, @directory)
+    end
+  end
+
+  private
+
+  def packages_in_build
+    puts "Finding packages for Task: #{@task_id}"
+    info = build_info
+    info.scan(/href=".*.rpm"/).collect { |link| link.split('name=')[1].gsub('"', '') }
+  end
+
+  def build_info
+    open("#{KOJI_URL}/koji/taskinfo?taskID=#{task_id}").read
+  end
+
+  def download_scratch_build(package, directory)
+    puts "Downloading #{package} to #{directory}"
+    File.open("#{directory}/#{package}", 'wb') do |file|
+      file << open("#{KOJI_URL}/koji/getfile?taskID=#{@task_id}&name=#{package}").read
+    end
+  end
+
+end

--- a/lib/repo-maker.rb
+++ b/lib/repo-maker.rb
@@ -1,0 +1,60 @@
+class RepoMaker
+
+  attr_reader :name
+
+  def initialize(args)
+    @name = args.fetch(:name)
+    @directory = args.fetch(:directory)
+  end
+
+  def create
+    cleanup_repo_file
+    install_createrepo
+
+    puts "Running createrepo on #{@directory}"
+    system("createrepo #{@directory}")
+    system("chmod -R o-w+r #{@directory}")
+
+    deploy_repo_file
+  end
+
+  private
+
+  def cleanup_repo_file
+    if File.exist?(repo_file)
+      File.delete(repo_file)
+    end
+  end
+
+  def install_createrepo
+    installed = system('rpm -q createrepo')
+
+    puts installed
+    if !installed
+      puts "Installing createrepo"
+      system('yum -y install createrepo')
+    end
+  end
+
+  def deploy_repo_file
+    puts "Deploying local repo file"
+
+    repo = "[#{hyphen_name}]\n" \
+           "name=Local repository for #{@name}\n" \
+           "baseurl=file://#{File.expand_path(@directory)}\n" \
+           "enabled=1\n" \
+           "gpgcheck=0\n" \
+           "protect=1"
+
+    File.open(repo_file, 'w') { |file| file.write(repo) }
+  end
+
+  def hyphen_name
+    @name.downcase.split(' ').join('-')
+  end
+
+  def repo_file
+    "/etc/yum.repos.d/#{hyphen_name}.repo"
+  end
+
+end


### PR DESCRIPTION
This provides the ability to pass a Koji build task ID and have those
RPMs made available for the installation. This is achieved by:

1. Find each RPM associated with the task and download them to ./repo
2. Turn ./repo into a local yum repo
3. Deploy a repo file to /etc/yum.repos.d pointing to the local repo