### PR TITLE
Fix formatting of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ module APlugin
     end
   end
 end
+```
 
 ### Troubleshooting
 


### PR DESCRIPTION
The README was oddly formatted after the Plugins section. Adding a ``` seems to fix it.