### PR TITLE
clean yum cache to prevent breakages during repo pushes

### DIFF
--- a/bats/fb-install-katello.bats
+++ b/bats/fb-install-katello.bats
@@ -93,6 +93,7 @@ setup() {
 }
 
 @test "install CLI (hammer)" {
+  yum clean all
   tPackageInstall foreman-cli
 }
 


### PR DESCRIPTION
occasionally the bats test will fail if it occurs during a foreman push of their repo.  This should help alleviate that.