### PR TITLE
Remove branch parameter from bootstrap bats

### DIFF
--- a/bats/bootstrap.sh
+++ b/bats/bootstrap.sh
@@ -11,4 +11,4 @@ if [ -d "katello-deploy" ]; then
   rm -rf katello-deploy
 fi
 
-git clone https://github.com/katello/katello-deploy.git -b bats && katello-deploy/bats/install.sh /usr/local
+git clone https://github.com/katello/katello-deploy.git && katello-deploy/bats/install.sh /usr/local


### PR DESCRIPTION
There is no branch or tag bats in the repository so using this parameter in git clone would normally result in a `fatal: Remote branch bats not found in upstream origin`