### PR TITLE
Enable bats without Vagrant

### DIFF
--- a/bats/fb-install-katello-devel.bats
+++ b/bats/fb-install-katello-devel.bats
@@ -57,7 +57,9 @@ setup() {
   if [ -e "/vagrant/setup.rb" ]; then
     cd /vagrant
   else
-    wget https://raw.githubusercontent.com/Katello/katello-deploy/master/setup.rb
+    wget https://github.com/Katello/katello-deploy/archive/master.zip
+    unzip master.zip
+    cd katello-deploy-master
   fi
   ruby setup.rb --devel
 }

--- a/bats/fb-install-katello.bats
+++ b/bats/fb-install-katello.bats
@@ -57,7 +57,9 @@ setup() {
   if [ -e "/vagrant/setup.rb" ]; then
     cd /vagrant
   else
-    wget https://raw.githubusercontent.com/Katello/katello-deploy/master/setup.rb
+    wget https://github.com/Katello/katello-deploy/archive/master.zip
+    unzip master.zip
+    cd katello-deploy-master
   fi
 
   if [ $USE_KOJI_REPOS ]; then


### PR DESCRIPTION
katello-bats currently depends on Vagrant. If you run it on a bare-metal host, even though it tries to wget setup.rb, it will fail with the following error as it cannot load any of the requires:

` /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:53:in require': cannot load such file -- ./helper (LoadError) `

Instead I'm getting the whole repo and unzipping it, so that it's able to run in non-vagrant machines, at least without having to read the source and create a /vagrant directory with the contents of katello-deploy :smiley_cat: 