### PR TITLE
Eliminate dots in hostname that don't separate the domains

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ module KatelloDeploy
   def self.define_vm(config, box = {})
     config.vm.define box.fetch(:name), primary: box.fetch(:default, false) do |machine|
       machine.vm.box      = box.fetch(:box_name)
-      machine.vm.hostname = "katello-#{box.fetch(:name)}.example.com"
+      machine.vm.hostname = "katello-#{box.fetch(:name).gsub('.','-')}.example.com"
       config.ssh.insert_key = false if SUPPORT_SSH_INSERT_KEY
 
       if box[:shell]


### PR DESCRIPTION
I had issues with hostnames like katello-centos7-2.2.example.com when using
dnsmasq to resolve them: my guess is the .2. being understood as additional
domain. I've replaces the dot's in the box name with '-' to fix this issue.