### PR TITLE
typo our to out

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The box can now be accessed via ssh and the Rails server started directly:
 
 ### Adding Custom Boxes
 
-Sometimes you want to spin up the same box type (e.g. centos7-devel) from within the katello-deploy directory. While this can be added to the Vagrantfile directly, updates to the katello-deploy repository could wipe our your local changes. To help with this, you can define a custom box re-using the configuration within the Vagrantfile. To do so, create a `boxes.yaml` file. For example, to create a custom box on CentOS 7 with nightly and run the installers reset command:
+Sometimes you want to spin up the same box type (e.g. centos7-devel) from within the katello-deploy directory. While this can be added to the Vagrantfile directly, updates to the katello-deploy repository could wipe out your local changes. To help with this, you can define a custom box re-using the configuration within the Vagrantfile. To do so, create a `boxes.yaml` file. For example, to create a custom box on CentOS 7 with nightly and run the installers reset command:
 
 ```
 my-nightly-test:


### PR DESCRIPTION
The Custom Boxes section stated 'could wipe our your local changes.' I changed our to out so it actually makes sense.