### PR TITLE
Remove plugins from koji repos configuration option.

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -178,17 +178,10 @@ def setup_koji_repos(os, version='nightly', foreman_version='nightly')
               "gpgcheck=0\n" \
               "baseurl=http://koji.katello.org/releases/yum/foreman-#{foreman_version}/RHEL/#{os}/x86_64/"
 
-  plugins = "[plugins-koji]\n" \
-              "name=plugins-koji\n" \
-              "enabled=1\n" \
-              "gpgcheck=0\n" \
-              "baseurl=http://koji.katello.org/releases/yum/foreman-plugins-#{foreman_version}/RHEL/#{os}/x86_64/"
-
   File.open("/etc/yum.repos.d/katello-koji.repo", 'w') { |file| file.write(katello) }
   File.open("/etc/yum.repos.d/pulp-koji.repo", 'w') { |file| file.write(pulp) }
   File.open("/etc/yum.repos.d/candlepin-koji.repo", 'w') { |file| file.write(candlepin) }
   File.open("/etc/yum.repos.d/foreman-koji.repo", 'w') { |file| file.write(foreman) }
-  File.open("/etc/yum.repos.d/plugins-koji.repo", 'w') { |file| file.write(plugins) }
 end
 
 if options[:os] == 'fedora19'


### PR DESCRIPTION
The plugins repository is special in that it houses multiple versions
of plugins. The Koji version of the repository only contains the latest
built package which can lead to issues if a major version is generated.