### PR TITLE
Configure foreman-plugins manually if using koji repos from published re...

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -178,10 +178,18 @@ def setup_koji_repos(os, version='nightly', foreman_version='nightly')
               "gpgcheck=0\n" \
               "baseurl=http://koji.katello.org/releases/yum/foreman-#{foreman_version}/RHEL/#{os}/x86_64/"
 
+  plugins = "[foreman-plugins]\n" \
+              "name=foreman-plugins\n" \
+              "enabled=1\n" \
+              "gpgcheck=0\n" \
+              "baseurl=http://yum.theforeman.org/plugins/#{foreman_version}/#{os}/x86_64/"
+
+
   File.open("/etc/yum.repos.d/katello-koji.repo", 'w') { |file| file.write(katello) }
   File.open("/etc/yum.repos.d/pulp-koji.repo", 'w') { |file| file.write(pulp) }
   File.open("/etc/yum.repos.d/candlepin-koji.repo", 'w') { |file| file.write(candlepin) }
   File.open("/etc/yum.repos.d/foreman-koji.repo", 'w') { |file| file.write(foreman) }
+  File.open("/etc/yum.repos.d/foreman-plugins.repo", 'w') { |file| file.write(plugins) }
 end
 
 if options[:os] == 'fedora19'


### PR DESCRIPTION
...pos.

Prior commit removed configuring plugins from Koji, however, in a normal
situation the foreman release RPM would setup the plugins repository.
Since we are configuring Foreman repos from Koji manually, we need to
still setup the plugins repository pointing at the published repository.