### PR TITLE
Update ca-certificates on deploy so bats test pass.

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -130,7 +130,7 @@ end
 # Make sure to clean packages metadata
 system('yum clean all')
 
-system('yum -y update nss')
+system('yum -y update nss ca-certificates')
 
 options[:os] ||= detect_os
 


### PR DESCRIPTION
Recent breakages in bats test on EL7 when installing the bootstrap
certificate are a result of https://bugzilla.redhat.com/show_bug.cgi?id=988745