### PR TITLE
Updated centos to 6.6 and 7.1 for virtualbox for use with Vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ module KatelloDeploy
       :image_name => /CentOS 6.*PV/,
       :default    => true,
       :pty        => true,
-      :virtualbox => 'http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-x86_64-v20130731.box',
+      :virtualbox => 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-6.6_chef-provisionerless.box',
       :libvirt    => 'http://m0dlx.com/files/foreman/boxes/centos64.box'
     },
     :centos7 => {
@@ -22,6 +22,7 @@ module KatelloDeploy
       :image_name => /CentOS 7.*PV/,
       :default    => true,
       :pty        => true,
+      :virtualbox => 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box',
       :libvirt    => 'https://download.gluster.org/pub/gluster/purpleidea/vagrant/centos-7.1/centos-7.1.box'
     }
   }


### PR DESCRIPTION
Opscode VMs do not ship chef and are "bare" VM Boxes for Vagrant, however they are constantly built by Opscode with Hashicorp's packer when updates get put out. So they will be up-to-date so at least Vagrant will function for virtualbox.