### PR TITLE
Refactor Vagrantfile.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ MethodLength:
 HashSyntax:
   Enabled: false # don't force 1.9 hash syntax
 
+Metrics/AbcSize:
+  Max: 20
+
 Style/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 

--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -1,0 +1,68 @@
+shells:
+  install_shell: &install_shell
+    shell: 'yum -y install ruby && cd /vagrant && ./setup.rb'
+  bats_shell: &bats_shell
+    shell: '/vagrant/bats/bootstrap_vagrant.sh'
+
+boxes:
+  centos6:
+    box_name:   'centos6'
+    image_name: !ruby/regexp '/CentOS 6.*PV/'
+    default:    true
+    pty:        true
+    virtualbox: 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-6.6_chef-provisionerless.box'
+    libvirt:    'http://m0dlx.com/files/foreman/boxes/centos64.box'
+
+  centos7:
+    box_name:   'centos7_1'
+    image_name: !ruby/regexp '/CentOS 7.*PV/'
+    default:    true
+    pty:        true
+    virtualbox: 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box'
+    libvirt:    'https://download.gluster.org/pub/gluster/purpleidea/vagrant/centos-7.1/centos-7.1.box'
+
+  centos6-nightly:
+    box:  centos6
+    <<: *install_shell
+
+  centos6-2.1:
+    box: centos6
+    <<: *install_shell
+    options: --version=2.1
+
+  centos6-2.2:
+    box: centos6
+    <<: *install_shell
+    options: --version=2.2
+
+  centos6-bats:
+    box: centos6
+    <<: *bats_shell
+
+  centos6-devel:
+    box: centos6
+    <<: *install_shell
+    options: --devel
+
+  centos7-nightly:
+    box:  centos7
+    <<: *install_shell
+
+  centos7-2.1:
+    box: centos7
+    <<: *install_shell
+    options: --version=2.1
+
+  centos7-2.2:
+    box: centos7
+    <<: *install_shell
+    options: --version=2.2
+
+  centos7-bats:
+    box: centos7
+    <<: *bats_shell
+
+  centos7-devel:
+    box: centos7
+    <<: *install_shell
+    options: --devel

--- a/lib/katello_deploy/box_loader.rb
+++ b/lib/katello_deploy/box_loader.rb
@@ -1,0 +1,59 @@
+module KatelloDeploy
+  class BoxLoader
+
+    attr_accessor :boxes, :shells
+
+    def initialize
+      @boxes = {}
+      @shells = {}
+    end
+
+    def add_boxes(box_file)
+      config = YAML.load_file(box_file)
+
+      process_shells(config['shells']) if config.key?('shells')
+
+      if config.key?('boxes')
+        process_boxes(config['boxes'])
+      else
+        process_boxes(config)
+      end
+
+      @boxes
+    end
+
+    private
+
+    def process_shells(shells)
+      @shells.merge!(shells)
+    end
+
+    def process_boxes(boxes)
+      boxes.each do |name, box|
+        box['name'] = name
+        box = layer_base_box(box)
+        box['shell'] += " #{box['options']} " if box['shell'] && box['options']
+        box['shell'] += " --installer-options='#{box['installer']}' " if box['shell'] && box['installer']
+
+        if @boxes[name]
+          @boxes[name].merge!(box)
+        else
+          @boxes[name] = box
+        end
+      end
+
+      @boxes
+    end
+
+    def layer_base_box(box)
+      return box unless (base_box = find_base_box(box['box']))
+      base_box.merge(box)
+    end
+
+    def find_base_box(name)
+      return false if name.nil?
+      @boxes[name]
+    end
+
+  end
+end

--- a/test/lib/box_loader_test.rb
+++ b/test/lib/box_loader_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class TestBoxLoader < Minitest::Test
+
+  def setup
+    @box_loader = KatelloDeploy::BoxLoader.new
+  end
+
+  def test_load
+    assert @box_loader.add_boxes('config/base_boxes.yaml')
+  end
+
+  def test_centos6
+    boxes = @box_loader.add_boxes('config/base_boxes.yaml')
+    assert_equal 'centos6-nightly', boxes['centos6-nightly']['name']
+    assert_equal 'centos6', boxes['centos6-nightly']['box_name']
+  end
+
+end


### PR DESCRIPTION
This refactors out the box processing logic into it's own testable
class. Further, the boxes are moved into a configuration file and
loaded/defined the same as custom boxes were loaded and defined
previously.

This does introduce one "api" change in that the previous "nightly"
boxes are renamed to "centos6-nightly" and "centos7-nightly". This
also means that the base centos6 and centos7 boxes (those without any
ties to install scripts etc.) are available as first class citizens.
In other words, you can vagrant up a bare bones centos6 or centos7 box
directly now.