### PR TITLE
Fix repository enable commands

### DIFF
--- a/lib/katello_deploy/repositories.rb
+++ b/lib/katello_deploy/repositories.rb
@@ -46,10 +46,10 @@ module KatelloDeploy
       # Setup RHEL specific repos
       system("yum -y  --disablerepo=\"*\" --enablerepo=rhel-#{os_version}-server-rpms install yum-utils wget")
       system('yum repolist') # TODO: necessary?
-      system('yum-CONFIG-manager --disable "*"')
-      system('yum-CONFIG-manager --enable epel')
+      system('yum-config-manager --disable "*"')
+      system('yum-config-manager --enable epel')
       system(
-        "subscription-manager repos --enable rhel-#{os_version}-server-rpms" \
+        "subscription-manager repos --enable rhel-#{os_version}-server-rpms " \
         "--enable rhel-#{os_version}-server-extras-rpms --enable rhel-#{os_version}-server-optional-rpms"
       )
       # As epel repo uses mirrorlist and yum vars.


### PR DESCRIPTION
Make sure to call `yum-config-manager` instead of `yum-CONFIG-manager`.
Also fix subscription-manager call to enable rhel repositories.

Closes #156