### PR TITLE
Change production version to 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ subscription-manager register --username USER --password PASSWORD --auto-attach
 
 For a release version in production:
 
-    ./setup.rb --version 2.0
+    ./setup.rb --version 2.2
 
 For nightly production:
 


### PR DESCRIPTION
Update the Readme to reflect current production version for direct deployment.
--version 2.0 no longer an option in setup.rb. Updated to --version 2.2