### PR TITLE
add per-box memory and cpu fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ installer -- options that you would like passed to the katello-installer
 options -- options that setup.rb accepts, e.g. --skip-installer
 shell -- customize the shell script run
 bridged -- deploy on Libvirt with a bridged networking configuration, value of this parameter should be the interface of the host (e.g. em1)
+memory -- set the amount of memory (in megabytes) this box will consume
+cpus -- set the number of cpus this box will use
 ```
 
 Entirely new boxes can be created that do not orginate from a box defined within the Vagrantfile. For example, if you had access to a RHEL Vagrant box:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,11 +51,15 @@ module KatelloDeploy
         override.vm.box_url = box.fetch('libvirt')
         override.vm.synced_folder ".", "/vagrant", type: "rsync"
         override.vm.network :public_network, :dev => box.fetch('bridged'), :mode => 'bridge' if box.fetch('bridged', false)
+        p.cpus = box.fetch('cpus') if box.fetch('cpus', false)
+        p.memory = box.fetch('memory') if box.fetch('memory', false)
       end
 
       if box.key?('virtualbox')
         machine.vm.provider :virtualbox do |p, override|
           override.vm.box_url = box.fetch('virtualbox')
+          p.cpus = box.fetch('cpus') if box.fetch('cpus', false)
+          p.memory = box.fetch('memory') if box.fetch('memory', false)
 
           if box.fetch('name').to_s.include?('devel')
             config.vm.network :forwarded_port, guest: 3000, host: 3330


### PR DESCRIPTION
You can now include `memory` and `cpus` fields in `boxes.yaml` for your
custom boxes. Memory is specified in number of megabytes.

Example:

```yaml
# boxes.yaml

devbox6:
  box: centos6-devel
  bridged: br0
  memory: 12288
  cpus: 2

devbox7:
  box: centos7-devel
  bridged: br0
  memory: 12288
  cpus: 2
```