### PR TITLE
sort scripts before running them

### DIFF
--- a/lib/katello_deploy/processors/scripts_processor.rb
+++ b/lib/katello_deploy/processors/scripts_processor.rb
@@ -14,7 +14,7 @@ module KatelloDeploy
       def self.run_scripts
         scripts = Dir.glob('*').select { |e| File.file? e }
 
-        scripts.each do |script|
+        scripts.sort.each do |script|
           system("./#{script}")
         end
       end


### PR DESCRIPTION
This may not apply to everyone, but the scripts I wrote to be executed
after Katello finishes installing are to be run in order. For the most
part they seemed to go in order, but I upgraded rubies and that seems to
be less consistent now. I added an explicit call to sort.

```
# directory structure
./scripts
  10-packages.bash
  20-dotfiles.bash
  30-foretello.bash
  40-hammer.bash
```