### PR TITLE
Fix module pull request support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ group :test do
   gem 'mocha'
   gem 'rubocop'
 end
+
+gem 'librarian-puppet'
+gem 'puppet', '< 4.0.0'

--- a/lib/katello_deploy/module_pull_request.rb
+++ b/lib/katello_deploy/module_pull_request.rb
@@ -39,11 +39,16 @@ module KatelloDeploy
         Dir.chdir(installer_path) do
           system('git fetch origin')
           system('git checkout origin/master')
+          system('rm -rf modules')
         end
       else
         Dir.chdir(@base_path) do
           system('git clone https://github.com/Katello/katello-installer.git')
         end
+      end
+
+      Dir.chdir(installer_path) do
+        system('librarian-puppet install --verbose')
       end
     end
 
@@ -59,7 +64,7 @@ module KatelloDeploy
 
     def find_git_url(puppet_module)
       split = @puppetfile.split("\n")
-      entry = split.select { |item| item.to_s =~ /#{puppet_module}/ }[0]
+      entry = split.select { |item| item.to_s =~ /\-#{puppet_module}/ }[0]
       entry.split(',')[1].split('git => ')[1]
     end
 


### PR DESCRIPTION
We need to run librarian first now that modules aren't in the git repo. Also, the git url
for katello was being set to candlepin because we matched the first line with katello in it.