### PR TITLE
Use prefixed params for setting devel_user

### DIFF
--- a/lib/katello_deploy/processors/installer_options_processor.rb
+++ b/lib/katello_deploy/processors/installer_options_processor.rb
@@ -9,7 +9,8 @@ module KatelloDeploy
         return installer_options if devel_user.nil?
 
         directory = deployment_dir || "/home/#{devel_user}"
-        "#{installer_options} --user=#{devel_user} --group=#{devel_user} --deployment-dir=#{directory}"
+        "#{installer_options} --katello-devel-user=#{devel_user}"\
+        " --certs-group=#{devel_user} --katello-deployment-dir=#{directory}"
       end
     end
   end

--- a/test/lib/processors/installer_options_processor_test.rb
+++ b/test/lib/processors/installer_options_processor_test.rb
@@ -18,7 +18,8 @@ class TestInstallerOptionsProcessor < Minitest::Test
       :installer_options => @installer_options,
       :devel_user => 'testuser'
     )
-    @installer_options = "#{@installer_options} --user=testuser --group=testuser --deployment-dir=/home/testuser"
+    @installer_options = "#{@installer_options} --katello-devel-user=testuser"\
+        ' --certs-group=testuser --katello-deployment-dir=/home/testuser'
 
     assert_equal installer_options, @installer_options
   end


### PR DESCRIPTION
With https://github.com/Katello/katello-installer/pull/303 merged the params in katello-devel scenario will be prefixed