### PR TITLE
Allow 2048MB swapfile to be created

### DIFF
--- a/bats/katello-bats
+++ b/bats/katello-bats
@@ -9,6 +9,7 @@ Usage: $0 [options]
       devel       Run bats against development
       content     Run content tests (yum + puppet)
       virt-whom   Run virt-whom candlepin tests
+      swapfile    Create a 2048MB swapfile
 EOF
 }
 
@@ -31,6 +32,9 @@ for arg do
         ;;
       virt-whom)
         katello_virt_whom=true
+        ;;
+      swapfile)
+        swapfile=true
         ;;
    esac
 done
@@ -59,6 +63,12 @@ fi
 if [ "$katello_virt_whom" == true ];
 then
     BATS_ARGS="$BATS_ARGS fb-virt-whom.bats"
+fi
+
+if [ "$swapfile" == true ];
+then
+    # add the swapfile command to the start of the args, so it runs before tests occur
+    BATS_ARGS="swapfile.bats $BATS_ARGS"
 fi
 
 cd /opt/bats

--- a/bats/swapfile.bats
+++ b/bats/swapfile.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+# vim: ft=sh:sw=2:ts=2:noet
+
+set -o pipefail
+
+@test "create swap file" {
+  swapsize=2048 # in MB
+  fallocate -l ${swapsize}M /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  echo '/swapfile none swap defaults 0 0' >> /etc/fstab
+}


### PR DESCRIPTION
Bats runs will occasionally fail due to the OOM killer appearing and killing a process. This is a quick workaround to add additional swap space to keep the OOM killer at bay. I did not notice any egregious usage of memory during bats runs.