### PR TITLE
Increase swap space, swappiness and remote pkg install timeout

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -141,7 +141,7 @@ EOF
 }
 
 @test "install package remotely (katello-agent)" {
-  timeout 120 hammer -u admin -p changeme host package install --host $(hostname -f) \
+  timeout 300 hammer -u admin -p changeme host package install --host $(hostname -f) \
     --packages walrus
   tPackageExists walrus
 }

--- a/bats/swapfile.bats
+++ b/bats/swapfile.bats
@@ -4,10 +4,11 @@
 set -o pipefail
 
 @test "create swap file" {
-  swapsize=2048 # in MB
+  swapsize=4096 # in MB
   dd if=/dev/zero of=/swapfile bs=1048576 count=$swapsize
   chmod 600 /swapfile
   mkswap /swapfile
   swapon /swapfile
   echo '/swapfile none swap defaults 0 0' >> /etc/fstab
+  sysctl vm.swappiness=60
 }


### PR DESCRIPTION
Bats tests were passing when run in a local VM, but failing when run via
automation. When I ran the tests in the same environment as the automation VM,
I noticed that there was quite a bit of wait for disk IO (sometimes causing
test failures), and exhaustion of swap space.

This patch does three things:

 * increase `vm.swappiness` setting from zero to 60 (60 is typical kernel default,
   not sure why it's zero for the centos box). See
   https://en.wikipedia.org/wiki/Swappiness for more detail.

 * increase swap from 2GB to 4GB

 * increase remote command timeout from 2 minutes to 5 minutes

I previously noticed bats runs consuming all 2GB of swap, but after setting
swappiness to 60, the high water mark seems to be 500MB or so. I figured 4GB
was reasonable to give ample headroom to prefer disk cache over VM pages if
needed. Total space on `/` is 158GB.

I am not sure why two minutes is not sufficient for the remote package install
command during the bats suite. The actual processing of the task takes about
10-20 seconds from package install request to RPM db update based on log data.
Subsequent runs are in the same range. My only guess is that the system is
heavily loaded during the suite run and thus needs the extra time.