### PR TITLE
add sleep after Katello bats install

### DIFF
--- a/bats/fb-install-katello.bats
+++ b/bats/fb-install-katello.bats
@@ -112,3 +112,7 @@ setup() {
   [ x$FOREMAN_VERSION = "x1.3" ] && skip "Only supported on 1.4+"
   hammer -u admin -p changeme host info --name $(hostname -f)
 }
+
+@test "Zzzz.... (120 sec)" {
+  sleep 120
+}


### PR DESCRIPTION
There was a timeout issue that I was unable to reproduce when running the
installation and then tests as two commands, but was able to repro when running
everything straight-through.

This sleep replicates the "run one, pause, then run the other" behavior.