### PR TITLE
ignore .ruby-version and .ruby-gemset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ plugins
 scripts
 repo
 Gemfile.lock
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
If you use RVM then you might potentially need to set a ruby version and
gemset for your katello-deploy directory.

If the ``system`` ruby is not RVM's default ruby, then you might run
into some issues. It can help to specify a desired ruby version and
gemset for RVM to switch to whenever using katello-deploy.