### PR TITLE
Fix wrong call for custom networks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,8 @@ module KatelloDeploy
 
       networks = box.fetch('networks', [])
       networks = networks.map do |network|
-        network['options'] = network['options'].inject({}){ |memo,(k,v)| memo.update(k.to_sym => v) }
+        symbolized_options = network['options'].inject({}){ |memo,(k,v)| memo.update(k.to_sym => v) }
+        network.update('options' => symbolized_options)
       end
 
       if box.key?('libvirt')


### PR DESCRIPTION
The `network` array was getting produced in wrong format, causing:

```
/opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/kernel_v2/config/vm.rb:236:in
`network': wrong number of arguments (2 for 1) (ArgumentError)
       from /home/inecas/Projects/ws/lab/katello-deploy/Vagrantfile:70:in
`block (3 levels) in define_vm'

```