### PR TITLE
Add a 30 second sleep to allow gofer to connect

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -140,6 +140,10 @@ EOF
   service goferd status || service goferd start
 }
 
+@test "30 sec of sleep for groggy gofers" {
+  sleep 30
+}
+
 @test "install package remotely (katello-agent)" {
   timeout 300 hammer -u admin -p changeme host package install --host $(hostname -f) \
     --packages walrus


### PR DESCRIPTION
Users have seen 10-15 second delays from `gofer start` to client queue binding.
This patch adds a 30 second sleep to give gofer ample time to connect to its
queue before making a remote package installation request.

Previously I assumed that this would be covered by just waiting longer in the
package install command, but there needs to be a sleep *before* the pkg install
request happens.