### PR TITLE
fix haveged install and enable centos-release-cr for sub-man

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -110,6 +110,10 @@ gpgcheck=0
 priority=1
 enabled=1
 EOF
+  # newer subscription-manager requires centos 6.8 yum, which is available in CR repo
+  if tIsRHEL 6; then
+    tPackageExists centos-release-cr || tPackageInstall centos-release-cr
+  fi
   tPackageExists subscription-manager || tPackageInstall subscription-manager
   yum install -y subscription-manager
 }

--- a/bats/fb-install-katello.bats
+++ b/bats/fb-install-katello.bats
@@ -56,13 +56,9 @@ setup() {
   sed -ir "s/^\s*server\s*=.*/server = $(hostname -f)/g" /etc/puppet/puppet.conf
 }
 
-@test "enable haveged" {
-  if tIsRHEL 6; then
-    yum -y update ca-certificates
-    rpm -ivh "http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"; yum install -y haveged
-    service haveged start
-  elif tIsRHEL 7; then
-    rpm -ivh "http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"; yum install -y haveged
+@test "enable haveged (el7 only)" {
+  if tIsRHEL 7; then
+    tPackageExists "haveged" || tPackageInstall "haveged"
     systemctl start haveged
   fi
 }


### PR DESCRIPTION
The newest version of `subscription-manager` requires a yum version that
is only available in the CR repo for el6. See
https://github.com/candlepin/subscription-manager/commit/88f7183a7f0ab2955995e238cc221af5f4eadc3e.

Additionally, we only need `haveged` on el7, and epel is already enabled
by the time we get to the point in bats to install it.