### PR TITLE
allow hammer remote install command to time out

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -149,8 +149,9 @@ EOF
 }
 
 @test "install package remotely (katello-agent)" {
+  # see http://projects.theforeman.org/issues/15089 for bug related to "|| true"
   timeout 300 hammer -u admin -p changeme host package install --host $(hostname -f) \
-    --packages walrus
+    --packages walrus || true
   tPackageExists walrus
 }
 


### PR DESCRIPTION
Previously, this command would occasionally time out even after the
package was successfully installed. This causes bats to fail.

I put in a redmine issue for the erroneous timeout, see
http://projects.theforeman.org/issues/15089. This workaround should
allow bats to pass. Note that we still check for the package after the
command times out, and will fail the job if the package is not
installed.